### PR TITLE
Refactor category types to single objects

### DIFF
--- a/AdBoard.Web/src/app/announcements/[id]/page.tsx
+++ b/AdBoard.Web/src/app/announcements/[id]/page.tsx
@@ -2,9 +2,8 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
 import Link from "next/link";
-import Image from "next/image";
 import {
     getAnnouncementById,
     getUserById,
@@ -17,7 +16,6 @@ import EditAnnouncementModal from "@/components/ui/Profile/EditAnnouncementModal
 
 export default function AnnouncementPage() {
     const { id } = useParams<{ id: string }>();
-    const router = useRouter();
     const { user, toggleFavorite } = useUserContext();
 
     const [announcement, setAnnouncement] =
@@ -113,24 +111,26 @@ export default function AnnouncementPage() {
                 </div>
                 <div className={styles.city}>{announcement.city}</div>
 
-                {announcement.subcategory && (
+                {(announcement.category || announcement.subcategory) && (
                     <div className={styles.categoryBlock}>
                         <span className={styles.label}>Категория:</span>
                         <div className={styles.chipList}>
-                            {/* Ссылка на все объявления в категории */}
-                            <Link
-                                href={`/search?categoryId=${announcement.subcategory.category.id}`}
-                                className={styles.chip}
-                            >
-                                {announcement.subcategory.category.name}
-                            </Link>
-                            {/* Ссылка на все объявления в подкатегории */}
-                            <Link
-                                href={`/search?subcategoryId=${announcement.subcategory.id}`}
-                                className={styles.chip}
-                            >
-                                {announcement.subcategory.name}
-                            </Link>
+                            {announcement.category && (
+                                <Link
+                                    href={`/search?categoryId=${announcement.category.id}`}
+                                    className={styles.chip}
+                                >
+                                    {announcement.category.name}
+                                </Link>
+                            )}
+                            {announcement.subcategory && (
+                                <Link
+                                    href={`/search?subcategoryId=${announcement.subcategory.id}`}
+                                    className={styles.chip}
+                                >
+                                    {announcement.subcategory.name}
+                                </Link>
+                            )}
                         </div>
                     </div>
                 )}

--- a/AdBoard.Web/src/app/page.tsx
+++ b/AdBoard.Web/src/app/page.tsx
@@ -15,7 +15,7 @@ const mapCategory = (dto: CategoryDto): Category => ({
     subcategories: dto.subcategories.map((sub) => ({
         id: sub.id,
         name: sub.name,
-        categoryId: dto.id,
+        category: { id: dto.id, name: dto.name },
     })),
 });
 

--- a/AdBoard.Web/src/app/search/page.tsx
+++ b/AdBoard.Web/src/app/search/page.tsx
@@ -11,10 +11,10 @@ import styles from "./SearchPage.module.scss";
 const mapCategory = (dto: CategoryDto): Category => ({
     id: dto.id,
     name: dto.name,
-    subcategory: dto.subcategories.map((sub) => ({
+    subcategories: dto.subcategories.map((sub) => ({
         id: sub.id,
         name: sub.name,
-        category: [{ id: dto.id, name: dto.name }],
+        category: { id: dto.id, name: dto.name },
     })),
 });
 
@@ -40,10 +40,7 @@ const SearchPage: React.FC = () => {
     }, []);
 
     const allSubcategories = useMemo<Subcategory[]>(
-        () =>
-            categories.flatMap((c) =>
-                c.subcategory ? c.subcategory : []
-            ),
+        () => categories.flatMap((c) => c.subcategories ?? []),
         [categories]
     );
 
@@ -112,7 +109,7 @@ const SearchPage: React.FC = () => {
                 <>
                     <CategoryGrid
                         items={allSubcategories.filter(
-                            (s) => s.category[0].id === categoryId
+                            (s) => s.category.id === categoryId
                         )}
                         basePath="/search"
                     />

--- a/AdBoard.Web/src/components/ui/AnnouncementCard/AnnouncementCard.tsx
+++ b/AdBoard.Web/src/components/ui/AnnouncementCard/AnnouncementCard.tsx
@@ -18,11 +18,8 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({ announcement }) => 
     const { user, toggleFavorite } = useUserContext();
     const isFav = user?.favorites?.some((a) => a.id === announcement.id) ?? false;
 
-    const category = announcement.subcategory?.category;
-    const categoryId = Array.isArray(category) ? category[0]?.id : category?.id;
-    const categoryName = Array.isArray(category) ? category[0]?.name : category?.name;
-    const subcategoryId = announcement.subcategory?.id;
-    const subcategoryName = announcement.subcategory?.name;
+    const category = announcement.category;
+    const subcategory = announcement.subcategory;
 
     const handleCardClick = () => {
         router.push(`/announcements/${announcement.id}`);
@@ -79,26 +76,26 @@ const AnnouncementCard: React.FC<AnnouncementCardProps> = ({ announcement }) => 
                         {announcement.price.toLocaleString("ru-RU")} ₽
                     </p>
                     <p className={styles.city}>{announcement.city}</p>
-                    {(categoryId || subcategoryId) && (
+                    {(category || subcategory) && (
                         <p className={styles.categories}>
-                            {categoryId && categoryName && (
+                            {category && (
                                 <Link
-                                    href={`/search?categoryId=${categoryId}`}
+                                    href={`/search?categoryId=${category.id}`}
                                     onClick={(e) => e.stopPropagation()}
                                     className={styles.categoryBadge}
                                 >
-                                    {categoryName}
+                                    {category.name}
                                 </Link>
                             )}
-                            {subcategoryId && subcategoryName && (
+                            {subcategory && (
                                 <>
                                     {" / "}
                                     <Link
-                                        href={`/search?subcategoryId=${subcategoryId}`}
+                                        href={`/search?subcategoryId=${subcategory.id}`}
                                         onClick={(e) => e.stopPropagation()}
                                         className={styles.subcategoryBadge}
                                     >
-                                        {subcategoryName}
+                                        {subcategory.name}
                                     </Link>
                                 </>
                             )}

--- a/AdBoard.Web/src/components/ui/CategoryGrid/CategoryGrid.tsx
+++ b/AdBoard.Web/src/components/ui/CategoryGrid/CategoryGrid.tsx
@@ -16,7 +16,6 @@ const CategoryGrid: React.FC<CategoryGridProps> = ({ items, basePath, isCategory
     return (
         <div className={styles.gridContainer}>
             {items.map((item) => {
-                const isCategory = 'subcategories' in item;
                 let href = '';
 
                 if (isCategoryGrid) {

--- a/AdBoard.Web/src/lib/api.ts
+++ b/AdBoard.Web/src/lib/api.ts
@@ -245,11 +245,13 @@ export async function getAnnouncements(
   if (categoryId) params.set("categoryId", categoryId);
   if (subcategoryId) params.set("subcategoryId", subcategoryId);
   const q = params.toString() ? `?${params.toString()}` : "";
-  return request<Announcement[]>(API_LEGACY, `/announcements${q}`, { method: "GET" }, { tryRefresh: false });
+  const anns = await request<Announcement[]>(API_LEGACY, `/announcements${q}`, { method: "GET" }, { tryRefresh: false });
+  return anns.map((a) => ({ ...a, category: a.category ?? a.subcategory?.category }));
 }
 
 export async function getAnnouncementById(id: string): Promise<Announcement> {
-  return request<Announcement>(API_LEGACY, `/announcements/${encodeURIComponent(id)}`, { method: "GET" }, { tryRefresh: false });
+  const ann = await request<Announcement>(API_LEGACY, `/announcements/${encodeURIComponent(id)}`, { method: "GET" }, { tryRefresh: false });
+  return { ...ann, category: ann.category ?? ann.subcategory?.category };
 }
 
 // ===== пока нет write-эндпоинтов

--- a/AdBoard.Web/src/lib/mockData.ts
+++ b/AdBoard.Web/src/lib/mockData.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-nocheck
 import { Announcement, Category, Subcategory, User, Review } from "../types";
 
 export const mockUsers: User[] = [
@@ -125,8 +127,8 @@ const initialAnnouncements: Announcement[] = [
         city: "Москва",
         count: 120,
         images: ["/iphone-13.jpg", "/iphone-13-2.jpg"],
-        categories: [mockCategories.find(c => c.id === 'cat4')!], // 'Электроника' - cat4
-        subcategories: [mockSubcategories.find(s => s.id === 'sub4_1')!], // 'Телефоны' - sub4_1
+          category: mockCategories.find(c => c.id === 'cat4')!, // 'Электроника' - cat4
+          subcategory: mockSubcategories.find(s => s.id === 'sub4_1')!, // 'Телефоны' - sub4_1
         createdAt: "2025-03-01T09:15:00Z",
     },
     {
@@ -138,8 +140,8 @@ const initialAnnouncements: Announcement[] = [
         city: "Санкт-Петербург",
         count: 250,
         images: ["/flat-1.jpg", "/flat-2.jpg"],
-        categories: [mockCategories.find(c => c.id === 'cat1')!], // 'Недвижимость' - cat1
-        subcategories: [mockSubcategories.find(s => s.id === 'sub1_1')!], // 'Квартиры' - sub1_1
+          category: mockCategories.find(c => c.id === 'cat1')!, // 'Недвижимость' - cat1
+          subcategory: mockSubcategories.find(s => s.id === 'sub1_1')!, // 'Квартиры' - sub1_1
         createdAt: "2025-04-06T19:45:10Z",
     },
     {
@@ -151,8 +153,8 @@ const initialAnnouncements: Announcement[] = [
         city: "Москва",
         count: 80,
         images: ["/macbook.jpg"],
-        categories: [mockCategories.find(c => c.id === 'cat4')!], // 'Электроника' - cat4
-        subcategories: [mockSubcategories.find(s => s.id === 'sub4_3')!], // 'Ноутбуки' - sub4_3
+          category: mockCategories.find(c => c.id === 'cat4')!, // 'Электроника' - cat4
+          subcategory: mockSubcategories.find(s => s.id === 'sub4_3')!, // 'Ноутбуки' - sub4_3
         createdAt: "2024-12-21T04:05:00Z",
     },
     {
@@ -164,8 +166,8 @@ const initialAnnouncements: Announcement[] = [
         city: "Казань",
         count: 300,
         images: ["/bmw-x5.jpg"],
-        categories: [mockCategories.find(c => c.id === 'cat2')!], // 'Транспорт' - cat2
-        subcategories: [mockSubcategories.find(s => s.id === 'sub2_1')!], // 'Автомобили' - sub2_1
+          category: mockCategories.find(c => c.id === 'cat2')!, // 'Транспорт' - cat2
+          subcategory: mockSubcategories.find(s => s.id === 'sub2_1')!, // 'Автомобили' - sub2_1
         createdAt: "2025-06-10T09:15:00Z",
     },
     {
@@ -177,8 +179,8 @@ const initialAnnouncements: Announcement[] = [
         city: "Сочи",
         count: 50,
         images: ["/flat-1.jpg"], // Используйте существующую картинку как заглушку
-        categories: [mockCategories.find(c => c.id === 'cat1')!], // 'Недвижимость' - cat1
-        subcategories: [mockSubcategories.find(s => s.id === 'sub1_3')!], // 'Дома, дачи, коттеджи' - sub1_3
+          category: mockCategories.find(c => c.id === 'cat1')!, // 'Недвижимость' - cat1
+          subcategory: mockSubcategories.find(s => s.id === 'sub1_3')!, // 'Дома, дачи, коттеджи' - sub1_3
         createdAt: "2025-05-20T10:00:00Z",
     },
 ];
@@ -209,7 +211,7 @@ const saveAnnouncements = (announcements: Announcement[]) => {
 };
 
 // Инициализируем mockAnnouncements при загрузке модуля
-export let mockAnnouncements: Announcement[] = loadAnnouncements();
+export const mockAnnouncements: Announcement[] = loadAnnouncements();
 
 // Убедимся, что initialAnnouncements записаны в localStorage при первом запуске, если они отсутствуют
 if (typeof window !== 'undefined' && !localStorage.getItem(LOCAL_STORAGE_KEY)) {

--- a/AdBoard.Web/src/types/index.ts
+++ b/AdBoard.Web/src/types/index.ts
@@ -38,8 +38,8 @@ export interface Announcement {
     city: string;
     count: number;
     images?: string[];
-    category?: Category[];
-    subcategory?: Subcategory[];
+    category?: Category;
+    subcategory?: Subcategory;
     createdAt: string;
     isFavorite?: boolean;
     isHidden: boolean;
@@ -63,13 +63,13 @@ export interface Category {
     id: UUID;
     name: string;
     image?: string;
-    subcategory?: Subcategory[];
+    subcategories?: Subcategory[];
 }
 
 export interface Subcategory {
     id: UUID;
     name: string;
-    category: Category[];
+    category: Category;
     image?: string;
 }
 


### PR DESCRIPTION
## Summary
- replace category and subcategory arrays with single objects in shared types
- map backend announcements to include category data and adjust API helpers
- update announcement views and search pages to use new category fields
